### PR TITLE
[#98] refactor: LogicalRuntimeException logging change

### DIFF
--- a/BackEnd/src/main/java/everyone/delivery/demo/common/exception/ExceptionUtils.java
+++ b/BackEnd/src/main/java/everyone/delivery/demo/common/exception/ExceptionUtils.java
@@ -16,7 +16,7 @@ public class ExceptionUtils<T> {
      * @param logParam
      * @param <T>
      *
-     * optionalT 속에 null이 있으면 LogicalRuntimeException을 던지고 아니면 그 값을 리턴
+     * optionalT 속에 null이 있으면 LogicalRuntimeException 을 던지고 아니면 그 값을 리턴
      * @return
      */
     public static <T> T ifNullThrowElseReturnVal(Optional<T> optionalT, String logMsg, Object logParam){
@@ -43,7 +43,7 @@ public class ExceptionUtils<T> {
      * @param optionalT
      * @param logMsg
      * @param logParam
-     * optionalT 속에 값이 있으면 LogicalRuntimeException을 던진다.
+     * optionalT 속에 값이 있으면 LogicalRuntimeException 을 던진다.
      */
     public static void ifNotNullThrow(Optional<?> optionalT, String logMsg, Object logParam){
         if(optionalT.isPresent()){

--- a/BackEnd/src/main/java/everyone/delivery/demo/common/exception/LogicalRuntimeException.java
+++ b/BackEnd/src/main/java/everyone/delivery/demo/common/exception/LogicalRuntimeException.java
@@ -3,20 +3,25 @@ package everyone.delivery.demo.common.exception;
 import everyone.delivery.demo.common.exception.error.RestError;
 import lombok.Data;
 
+/***
+ * > 목적 1: 로직상 분기를 if ~ else 와 return 의 반복으로 안하고 보다 깔끔하게 하기 위함
+ * > 목적 2: spring 의 예외에 대한 handler & advice 기능을 활용하여 예외 상황 시 응답을 공통화 하기 위함
+ */
 @Data
 public class LogicalRuntimeException extends RuntimeException{
     private RestError restError;
 
-    public LogicalRuntimeException(){
-        super();
-    }
-
+    /***
+     * > 오로지 restError 를 인자로 받는 생성자만 허용
+     * > LogicalRuntimeException 은 반드시 restError 를 가져야 함을 강제한다.
+     * @param restError
+     */
     public LogicalRuntimeException(RestError restError){
         this.restError = restError;
     }
 
     /***
-     * 로직상 던지는 오류이기 때문에 stackTrace를 안만들도록(성능 up)
+     * 로직상 던지는 오류이기 때문에 stackTrace 를 안만들도록(성능 up)
      * 예외에 대한 로깅이 필수인 곳에는 사용하면 안됨
      * @return
      */

--- a/BackEnd/src/main/java/everyone/delivery/demo/common/exception/advice/CommonControllerAdvice.java
+++ b/BackEnd/src/main/java/everyone/delivery/demo/common/exception/advice/CommonControllerAdvice.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
-import javax.persistence.EntityResult;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
@@ -35,7 +34,7 @@ public class CommonControllerAdvice {
 
     @ExceptionHandler(LogicalRuntimeException.class)
     public ResponseEntity<?> logicalRuntimeExceptionHandler(LogicalRuntimeException ex) {
-        log.error("LogicalRuntimeException: ",  ex);
+        log.info("LogicalRuntimeException: {}",  ex.getRestError().getErrorMsg());
         return ResponseUtils.out(ex.getRestError());
     }
 
@@ -70,7 +69,7 @@ public class CommonControllerAdvice {
     protected ResponseEntity<?> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException ex) {
         log.error("MethodArgumentNotValidException: ",  ex);
 
-        //TODO: 별도의 ConstraintValidator가 없을 경우 동작 방식 확인 필요
+        //TODO: 별도의 ConstraintValidator 가 없을 경우 동작 방식 확인 필요
         try {
             // 별도의 ConstraintValidator에서 발생한 검증 오류의 경우 넘어온 에러 객체로 응답
             ConstraintViolation<?> constraintViolation = ex.getBindingResult().getAllErrors().get(0).unwrap(ConstraintViolation.class);

--- a/BackEnd/src/main/java/everyone/delivery/demo/common/exception/error/CommonError.java
+++ b/BackEnd/src/main/java/everyone/delivery/demo/common/exception/error/CommonError.java
@@ -2,10 +2,8 @@ package everyone.delivery.demo.common.exception.error;
 
 import everyone.delivery.demo.common.response.ResponseError;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import java.util.EnumSet;
 
 /***
  * 미리 정의해 둔 에러들


### PR DESCRIPTION
* 순수한 예외가 아니라 로직 상 분기 처리를 위해 만들어 둔 `LogicalRuntimeException` 에 대한 stackTrace 로그를 불필요하게 찍고 있는 부분을 수정하기 위해 [https://github.com/Everyone-s-delivery/Web/issues/98#issuecomment-1152849348] 를 진행했습니다.